### PR TITLE
Avoid using "longest common substring" term in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lcs
 
-A library for finding longest common substrings. You can also use this library
+A library for finding longest common subsequences. You can also use this library
 to calculate a diff between two sequences.
 
 ## Example


### PR DESCRIPTION
The [longest common substring problem](https://en.wikipedia.org/wiki/Longest_common_substring_problem) is separate problem from the [longest common subsequence problem](https://en.wikipedia.org/wiki/Longest_common_subsequence_problem). You should avoid the term.
