### PR TITLE
Remove recursive functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,6 +209,14 @@ impl<'a, T> LcsTable<'a, T> where T: Eq {
         rest_diff.push(to_add);
         rest_diff
     }
+
+    /// Retrieve length of longest common subsequences.
+    pub fn length(&self) -> i64 {
+        if self.a.len() == 0 || self.b.len() == 0 {
+            return 0
+        }
+        self.lengths[self.a.len()][self.b.len()]
+    }
 }
 
 #[test]
@@ -239,6 +247,7 @@ fn test_lcs_lcs() {
     let table = LcsTable::new(&a, &b);
     let lcs = table.longest_common_subsequence();
     assert_eq!(vec![(&'a', &'a'), (&'b', &'b'), (&'c', &'c')], lcs);
+    assert_eq!(3, table.length());
 }
 
 #[test]
@@ -252,6 +261,7 @@ fn test_longest_common_subsequences() {
     assert!(subsequences.contains(&vec![(&'a', &'a'), (&'c', &'c')]));
     assert!(subsequences.contains(&vec![(&'g', &'g'), (&'a', &'a')]));
     assert!(subsequences.contains(&vec![(&'g', &'g'), (&'c', &'c')]));
+    assert_eq!(2, table.length());
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,3 +344,39 @@ fn test_diff() {
         Insertion(&'c')
     ]);
 }
+
+#[test]
+fn test_empty_one() {
+    use DiffComponent::*;
+
+    let a: Vec<_> = "".chars().collect();
+    let b: Vec<_> = "abc".chars().collect();
+    let table = LcsTable::new(&a, &b);
+
+    let seq = table.longest_common_subsequence();
+    let seq_all = table.longest_common_subsequences();
+    let diff = table.diff();
+    assert_eq!(seq.len(), 0);
+    assert_eq!(seq_all.len(), 1);
+    assert!(seq_all.contains(&vec![]));
+    assert_eq!(diff, vec![
+        Insertion(&'a'),
+        Insertion(&'b'),
+        Insertion(&'c')
+    ]);
+}
+
+#[test]
+fn test_empty_both() {
+    let a: Vec<_> = "".chars().collect();
+    let b: Vec<_> = "".chars().collect();
+    let table = LcsTable::new(&a, &b);
+
+    let seq = table.longest_common_subsequence();
+    let seq_all = table.longest_common_subsequences();
+    let diff = table.diff();
+    assert_eq!(seq.len(), 0);
+    assert_eq!(seq_all.len(), 1);
+    assert!(seq_all.contains(&vec![]));
+    assert_eq!(diff.len(), 0);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,23 +64,26 @@ impl<'a, T> LcsTable<'a, T> where T: Eq {
     /// assert_eq!(vec![(&'a', &'a'), (&'b', &'b'), (&'c', &'c')], lcs);
     /// ```
     pub fn longest_common_subsequence(&self) -> Vec<(&T, &T)> {
-        self.find_lcs(self.a.len(), self.b.len())
-    }
+        let mut seq = Vec::with_capacity(self.length() as usize);
+        let mut i = self.a.len();
+        let mut j = self.b.len();
 
-    fn find_lcs(&self, i: usize, j: usize) -> Vec<(&T, &T)> {
-        if i == 0 || j == 0 {
-            return vec![];
-        }
+        loop {
+            if i == 0 || j == 0 {
+                seq.reverse();
+                return seq;
+            }
 
-        if self.a[i - 1] == self.b[j - 1] {
-            let mut prefix_lcs = self.find_lcs(i - 1, j - 1);
-            prefix_lcs.push((&self.a[i - 1], &self.b[j - 1]));
-            prefix_lcs
-        } else {
-            if self.lengths[i][j - 1] > self.lengths[i - 1][j] {
-                self.find_lcs(i, j - 1)
+            if self.a[i - 1] == self.b[j - 1] {
+                seq.push((&self.a[i - 1], &self.b[j - 1]));
+                i -= 1;
+                j -= 1;
             } else {
-                self.find_lcs(i - 1, j)
+                if self.lengths[i][j - 1] > self.lengths[i - 1][j] {
+                    j -= 1;
+                } else {
+                    i -= 1;
+                }
             }
         }
     }


### PR DESCRIPTION
This pull request resolves #8 by rewriting all recursive functions as loops.
#### Benchmark before and after:

| Methode Name | String Lengths | Time Before | Time After |
| --- | --- | --- | --- |
| longest_common_subsequence() | 20000 chars | 2354μs | 4488μs |
| longest_common_subsequences() | 20 chars | 6145ms | 1691ms |
| diff() | 4000 chars | 1030μs | 389μs |

There is a decent performance degradation for `longest_common_subsequence()`. This is probably since we reverse the vector at end insted of inserting into the vector in the right order. I going to experiment with different ways to fill the vector.

This request includes and uses #7. So this should be merge after #7 if excepted.
