### PR TITLE
Allow a and b to be different types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ authors = ["Ulysse Carion <ulysse@ulysse.io>"]
 description = "A library for computing longest common subsequences and diffs"
 license = "MIT"
 homepage = "https://github.com/ucarion/rust-lcs"
+edition = "2015"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ use std::hash::Hash;
 use std::collections::HashSet;
 
 #[derive(Debug)]
-pub struct LcsTable<'a, A: 'a, B: 'a> {
+pub struct LcsTable<'a, A: 'a, B: 'a = A> {
     lengths: Vec<Vec<i64>>,
 
     a: &'a [A],
@@ -19,7 +19,7 @@ pub struct LcsTable<'a, A: 'a, B: 'a> {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub enum DiffComponent<A, B> {
+pub enum DiffComponent<A, B = A> {
     Insertion(B),
     Unchanged(A, B),
     Deletion(A)


### PR DESCRIPTION
Hi, thanks for making this crate available.

I have a use case where the elements of sequences `a` and `b` are comparable but have different types, this change supports that.